### PR TITLE
Add film use tracking

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -5,7 +5,7 @@ from sqlmodel import SQLModel
 
 from alembic import context
 
-from app.models import Film
+from app.models import Film, FilmUse
 from app.database import DATABASE_URL
 
 config = context.config

--- a/alembic/versions/0001_create_films_table.py
+++ b/alembic/versions/0001_create_films_table.py
@@ -15,7 +15,7 @@ depends_on = None
 def upgrade():
     op.create_table(
         'film',
-        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('id', sa.String(length=36), primary_key=True),
         sa.Column('manufacturer', sa.String(), nullable=False),
         sa.Column('name', sa.String(), nullable=False),
         sa.Column('type', sa.String(), nullable=False),

--- a/alembic/versions/0002_create_film_uses_table.py
+++ b/alembic/versions/0002_create_film_uses_table.py
@@ -1,0 +1,31 @@
+"""create film uses table
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2024-01-02 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0002'
+down_revision = '0001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'filmuse',
+        sa.Column('id', sa.String(length=36), primary_key=True),
+        sa.Column('date_used', sa.Date(), nullable=False),
+        sa.Column('film_id', sa.String(length=36), sa.ForeignKey('film.id'), nullable=False),
+        sa.Column('camera', sa.String(), nullable=False),
+        sa.Column('location', sa.String(), nullable=False),
+        sa.Column('developer', sa.String(), nullable=False),
+        sa.Column('notes', sa.String(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table('filmuse')

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from sqlmodel import SQLModel
 from contextlib import asynccontextmanager
 
 from .database import engine
-from .routers import films
+from .routers import films, uses
 
 
 @asynccontextmanager
@@ -14,3 +14,4 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Film Tracker API", lifespan=lifespan)
 app.include_router(films.router)
+app.include_router(uses.router)

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,8 @@
 from enum import Enum
 from typing import Optional
+from datetime import date
+from uuid import UUID
+import uuid6
 from sqlmodel import Field, SQLModel
 from pydantic import ConfigDict
 
@@ -16,10 +19,40 @@ class FilmFormat(str, Enum):
 
 class Film(SQLModel, table=True):
     model_config = ConfigDict(use_enum_values=True)
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: UUID = Field(default_factory=uuid6.uuid6, primary_key=True)
     manufacturer: str
     name: str
     type: FilmType = Field(sa_column_kwargs={"nullable": False})
     format: FilmFormat = Field(sa_column_kwargs={"nullable": False})
     iso: int
     quantity: int = 0
+
+
+class FilmUseBase(SQLModel):
+    """Base fields for logging a roll of film usage."""
+
+    date_used: date
+    film_id: UUID = Field(foreign_key="film.id")
+    camera: str
+    location: str
+    developer: str
+    notes: Optional[str] = None
+
+
+class FilmUse(FilmUseBase, table=True):
+    id: UUID = Field(default_factory=uuid6.uuid6, primary_key=True)
+
+
+class FilmUseCreate(FilmUseBase):
+    pass
+
+
+class FilmUseUpdate(SQLModel):
+    """Fields that can be updated for a film use."""
+
+    date_used: Optional[date] = None
+    film_id: Optional[UUID] = None
+    camera: Optional[str] = None
+    location: Optional[str] = None
+    developer: Optional[str] = None
+    notes: Optional[str] = None

--- a/app/routers/films.py
+++ b/app/routers/films.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import select
 from typing import List
+from uuid import UUID
 
 from ..models import Film
 from ..database import get_session
@@ -19,7 +20,7 @@ def create_film(film: Film, session=Depends(get_session)):
     return film
 
 @router.patch("/{film_id}", response_model=Film)
-def update_quantity(film_id: int, quantity: int, session=Depends(get_session)):
+def update_quantity(film_id: UUID, quantity: int, session=Depends(get_session)):
     film = session.get(Film, film_id)
     if not film:
         raise HTTPException(status_code=404, detail="Film not found")

--- a/app/routers/uses.py
+++ b/app/routers/uses.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import select
+from typing import List
+
+from uuid import UUID
+from ..models import FilmUse, FilmUseCreate, FilmUseUpdate
+from ..database import get_session
+
+router = APIRouter(prefix="/uses", tags=["film uses"])
+
+
+@router.get("/", response_model=List[FilmUse])
+def list_uses(session=Depends(get_session)):
+    uses = session.exec(select(FilmUse)).all()
+    return uses
+
+
+@router.post("/", response_model=FilmUse, status_code=201)
+def create_use(use: FilmUseCreate, session=Depends(get_session)):
+    film_use = FilmUse.model_validate(use.model_dump())
+    session.add(film_use)
+    session.flush()
+    return film_use
+
+
+@router.patch("/{use_id}", response_model=FilmUse)
+def update_use(use_id: UUID, use: FilmUseUpdate, session=Depends(get_session)):
+    film_use = session.get(FilmUse, use_id)
+    if not film_use:
+        raise HTTPException(status_code=404, detail="Film use not found")
+    for key, value in use.model_dump(exclude_unset=True).items():
+        setattr(film_use, key, value)
+    session.add(film_use)
+    return film_use

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "uvicorn",
     "sqlmodel",
     "alembic"
+    ,"uuid6"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 sqlmodel
 alembic
+uuid6

--- a/tests/test_uses.py
+++ b/tests/test_uses.py
@@ -1,0 +1,88 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine, Session
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_session
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    def get_session_override():
+        yield session
+    app.dependency_overrides[get_session] = get_session_override
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def test_create_and_list_use(client):
+    # create a film to reference
+    film_data = {
+        "manufacturer": "Ilford",
+        "name": "HP5+",
+        "type": "BW",
+        "format": "35mm",
+        "iso": 400,
+    }
+    film_resp = client.post("/films/", json=film_data)
+    assert film_resp.status_code == 201
+    film_id = film_resp.json()["id"]
+
+    use_data = {
+        "date_used": "2025-01-01",
+        "film_id": film_id,
+        "camera": "Nikon F3",
+        "location": "London",
+        "developer": "D76",
+        "notes": "First roll of the year",
+    }
+    response = client.post("/uses/", json=use_data)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["id"] is not None
+
+    response = client.get("/uses/")
+    assert response.status_code == 200
+    uses = response.json()
+    assert len(uses) == 1
+    assert uses[0]["camera"] == "Nikon F3"
+
+
+def test_update_use(client):
+    film_data = {
+        "manufacturer": "Kodak",
+        "name": "Gold 200",
+        "type": "Colour",
+        "format": "35mm",
+        "iso": 200,
+    }
+    film_resp = client.post("/films/", json=film_data)
+    film_id = film_resp.json()["id"]
+
+    use_data = {
+        "date_used": "2025-02-02",
+        "film_id": film_id,
+        "camera": "Canon AE-1",
+        "location": "Paris",
+        "developer": "C41",
+    }
+    use_resp = client.post("/uses/", json=use_data)
+    use_id = use_resp.json()["id"]
+
+    patch_resp = client.patch(f"/uses/{use_id}", json={"notes": "Updated"})
+    assert patch_resp.status_code == 200
+    assert patch_resp.json()["notes"] == "Updated"


### PR DESCRIPTION
## Summary
- track film usage in SQLModel
- create router for logging uses of film
- expose film uses in API
- create alembic migration for `filmuse` table
- test creating and listing film uses
- use UUIDv6 for film IDs as well as film uses

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-test.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f52e8159c8333b15fdaa290f9659e