### PR TITLE
Add integration tests to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,3 +21,35 @@ jobs:
           uv pip install --system -r requirements-test.txt
       - name: Run tests
         run: pytest -q
+
+  integration:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: film
+          POSTGRES_PASSWORD: film
+          POSTGRES_DB: filmdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U film"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql+psycopg2://film:film@localhost:5432/filmdb
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install uv
+        run: pip install uv
+      - name: Install dependencies
+        run: |
+          uv pip install --system -r requirements.txt
+          uv pip install --system -r requirements-test.txt
+      - name: Run integration tests
+        run: pytest -q tests/integration

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 pytest
 httpx
+psycopg2-binary

--- a/tests/integration/test_api_postgres.py
+++ b/tests/integration/test_api_postgres.py
@@ -1,0 +1,85 @@
+import os
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine, Session
+
+from app.main import app
+from app.database import get_session
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+psycopg2://film:film@localhost:5432/filmdb")
+
+@pytest.fixture(name="session")
+def session_fixture():
+    try:
+        engine = create_engine(DATABASE_URL)
+        SQLModel.metadata.create_all(engine)
+    except Exception:
+        pytest.skip("Postgres server not available")
+        return
+    with Session(engine) as session:
+        yield session
+    SQLModel.metadata.drop_all(engine)
+
+@pytest.fixture(name="client")
+def client_fixture(session):
+    def get_session_override():
+        yield session
+    app.dependency_overrides[get_session] = get_session_override
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+def test_films_endpoints(client):
+    film_data = {
+        "manufacturer": "Kodak",
+        "name": "Ektar 100",
+        "type": "Colour",
+        "format": "35mm",
+        "iso": 100,
+        "quantity": 3,
+    }
+    resp = client.post("/films/", json=film_data)
+    assert resp.status_code == 201
+    data = resp.json()
+    film_id = data["id"]
+
+    resp = client.get("/films/")
+    assert resp.status_code == 200
+    films = resp.json()
+    assert any(f["id"] == film_id for f in films)
+
+    resp = client.patch(f"/films/{film_id}", params={"quantity": 7})
+    assert resp.status_code == 200
+    assert resp.json()["quantity"] == 7
+
+
+def test_uses_endpoints(client):
+    film_data = {
+        "manufacturer": "Ilford",
+        "name": "HP5+",
+        "type": "BW",
+        "format": "35mm",
+        "iso": 400,
+    }
+    film_resp = client.post("/films/", json=film_data)
+    film_id = film_resp.json()["id"]
+
+    use_data = {
+        "date_used": "2025-01-01",
+        "film_id": film_id,
+        "camera": "Nikon F3",
+        "location": "London",
+        "developer": "D76",
+    }
+    resp = client.post("/uses/", json=use_data)
+    assert resp.status_code == 201
+    use_id = resp.json()["id"]
+
+    resp = client.get("/uses/")
+    assert resp.status_code == 200
+    uses = resp.json()
+    assert any(u["id"] == use_id for u in uses)
+
+    patch_resp = client.patch(f"/uses/{use_id}", json={"notes": "Updated"})
+    assert patch_resp.status_code == 200
+    assert patch_resp.json()["notes"] == "Updated"


### PR DESCRIPTION
## Summary
- create integration test using Postgres
- install psycopg2-binary for tests
- add integration test job in GitHub Actions workflow
- expand integration tests to cover all API endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f570ff2fc8333a5bf115434f84372