### PR TITLE
Fix alembic import path

### DIFF
--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -5,6 +5,11 @@ from sqlmodel import SQLModel
 
 from alembic import context
 
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from app.models import Film, FilmUse
 from app.database import DATABASE_URL
 


### PR DESCRIPTION
## Summary
- ensure `alembic/env.py` locates project packages by extending `sys.path`

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-test.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f6247ea7c8333bd34c65cb5fa1740