### PR TITLE
Fix missing psycopg2 dependency

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "sqlmodel",
     "alembic"
     ,"uuid6"
+    ,"psycopg2-binary"
 ]
 
 [project.optional-dependencies]

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 sqlmodel
 alembic
 uuid6
+psycopg2-binary


### PR DESCRIPTION
## Summary
- include `psycopg2-binary` in application dependencies

## Testing
- `pytest -q`
- `pytest -q tests/integration`


------
https://chatgpt.com/codex/tasks/task_e_683f6353ead88333beb232d85a487607