### PR TITLE
Fix session dependency for FastAPI

### DIFF
--- a/api/app/database.py
+++ b/api/app/database.py
@@ -1,12 +1,11 @@
 import os
 from sqlmodel import SQLModel, create_engine, Session
 from sqlalchemy.exc import SQLAlchemyError
-from contextlib import contextmanager
+
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./filmtracker.db")
 engine = create_engine(DATABASE_URL, echo=True)
 
-@contextmanager
 def get_session():
     session = Session(engine)
     try:


### PR DESCRIPTION
## Summary
- remove `@contextmanager` from `get_session`
- run tests

## Testing
- `pip install -q -r requirements.txt -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f654fa5e08333a99e14fdec6b4f70