### PR TITLE
Fix API proxy for production frontend

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,5 +7,6 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/default.conf
+++ b/frontend/default.conf
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass http://api:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- add nginx config to proxy /api requests to the FastAPI service
- copy this config in the frontend Dockerfile

## Testing
- `uv pip install --system -r requirements.txt`
- `uv pip install --system -r requirements-test.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6764fcac8333a39862f185a41316