### PR TITLE
Add per-row film updates and responsive layout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,8 +6,8 @@ import FilmUses from './pages/FilmUses'
 export default function App() {
   return (
     <BrowserRouter>
-      <div className="p-4 space-y-4">
-        <nav className="flex items-center gap-4 mb-4">
+      <div className="p-4 space-y-4 max-w-screen-lg mx-auto">
+        <nav className="flex flex-wrap items-center gap-4 mb-4">
           <Link to="/films" className="underline">
             Film Stock
           </Link>

--- a/frontend/src/pages/FilmStock.jsx
+++ b/frontend/src/pages/FilmStock.jsx
@@ -85,14 +85,10 @@ export default function FilmStock() {
     setEditedQuantities({ ...editedQuantities, [id]: quantity })
   }
 
-  const confirmUpdates = () => {
-    Promise.all(
-      films.map((film) =>
-        fetch(`/api/films/${film.id}?quantity=${editedQuantities[film.id]}`, {
-          method: 'PATCH'
-        })
-      )
-    ).then(fetchFilms)
+  const updateQuantity = (id) => {
+    fetch(`/api/films/${id}?quantity=${editedQuantities[id]}`, {
+      method: 'PATCH'
+    }).then(fetchFilms)
   }
 
   const handleSort = (field) => {
@@ -117,7 +113,7 @@ export default function FilmStock() {
   })
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 max-w-screen-lg mx-auto">
       <Button onClick={() => setShowModal(true)}>Add Film</Button>
       <Modal open={showModal} onClose={() => setShowModal(false)}>
         <h2 className="text-xl font-semibold mb-2">Add Film</h2>
@@ -254,6 +250,7 @@ export default function FilmStock() {
                 <th className="p-2 cursor-pointer" onClick={() => handleSort('quantity')}>
                   Quantity
                 </th>
+                <th className="p-2">Update</th>
               </tr>
             </thead>
             <tbody>
@@ -274,13 +271,15 @@ export default function FilmStock() {
                       }
                     />
                   </td>
+                  <td className="p-2">
+                    <Button size="sm" onClick={() => updateQuantity(film.id)}>
+                      Confirm
+                    </Button>
+                  </td>
                 </tr>
               ))}
             </tbody>
           </table>
-          <div className="mt-2 text-right">
-            <Button onClick={confirmUpdates}>Confirm Updates</Button>
-          </div>
         </div>
       </section>
     </div>

--- a/frontend/src/pages/FilmUses.jsx
+++ b/frontend/src/pages/FilmUses.jsx
@@ -69,7 +69,7 @@ export default function FilmUses() {
   const filmMap = Object.fromEntries(films.map((f) => [f.id, f]))
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 max-w-screen-lg mx-auto">
       <section>
         <h2 className="text-xl font-semibold mb-2">Log Film Use</h2>
         <form onSubmit={addUse} className="space-y-2">


### PR DESCRIPTION
## Summary
- add container and wrapping to main layout for responsiveness
- move film quantity updates to a per-row button
- keep pages within a centered responsive width

## Testing
- `cd api && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f70b5f50c8333980fe3710f4cd69c