### PR TITLE
Add film stock charts page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,9 @@
     "tailwind-merge": "^2.2.1",
     "class-variance-authority": "^0.7.0",
     "lucide-react": "^0.379.0",
-    "react-router-dom": "^6.23.0"
+    "react-router-dom": "^6.23.0",
+    "chart.js": "^4.4.1",
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Link, Navigate } from 'react-router-dom'
 import DarkModeToggle from './components/DarkModeToggle'
 import FilmStock from './pages/FilmStock'
 import FilmUses from './pages/FilmUses'
+import FilmStockCharts from './pages/FilmStockCharts'
 
 export default function App() {
   return (
@@ -14,6 +15,9 @@ export default function App() {
           <Link to="/uses" className="underline">
             Film Uses
           </Link>
+          <Link to="/charts" className="underline">
+            Charts
+          </Link>
           <div className="ml-auto">
             <DarkModeToggle />
           </div>
@@ -22,6 +26,7 @@ export default function App() {
           <Route path="/" element={<Navigate to="/films" replace />} />
           <Route path="/films" element={<FilmStock />} />
           <Route path="/uses" element={<FilmUses />} />
+          <Route path="/charts" element={<FilmStockCharts />} />
         </Routes>
       </div>
     </BrowserRouter>

--- a/frontend/src/pages/FilmStockCharts.jsx
+++ b/frontend/src/pages/FilmStockCharts.jsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react'
+import { Bar } from 'react-chartjs-2'
+import {
+  Chart as ChartJS,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend
+} from 'chart.js'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend)
+
+export default function FilmStockCharts() {
+  const [films, setFilms] = useState([])
+
+  useEffect(() => {
+    fetch('/api/films/')
+      .then((res) => res.json())
+      .then(setFilms)
+  }, [])
+
+  const byType = {}
+  const byFormat = {}
+  films.forEach((f) => {
+    byType[f.type] = (byType[f.type] || 0) + f.quantity
+    byFormat[f.format] = (byFormat[f.format] || 0) + f.quantity
+  })
+
+  const typeData = {
+    labels: Object.keys(byType),
+    datasets: [
+      {
+        label: 'Quantity',
+        data: Object.values(byType),
+        backgroundColor: 'rgba(59,130,246,0.7)'
+      }
+    ]
+  }
+
+  const formatData = {
+    labels: Object.keys(byFormat),
+    datasets: [
+      {
+        label: 'Quantity',
+        data: Object.values(byFormat),
+        backgroundColor: 'rgba(16,185,129,0.7)'
+      }
+    ]
+  }
+
+  return (
+    <div className="space-y-6 max-w-screen-lg mx-auto">
+      <h2 className="text-xl font-semibold mb-2">Film Stock Charts</h2>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <Bar data={typeData} />
+        </div>
+        <div>
+          <Bar data={formatData} />
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- display film stock information in charts
- link new charts page in the navigation menu
- include Chart.js dependencies

## Testing
- `npm run build` (frontend)
- `PYTHONPATH=api pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f71dcc1208333bca7294c564cb8d7