### PR TITLE
Fix UUID columns for Postgres

### DIFF
--- a/api/alembic/versions/0001_create_films_table.py
+++ b/api/alembic/versions/0001_create_films_table.py
@@ -6,6 +6,7 @@ Create Date: 2024-01-01 00:00:00.000000
 """
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 revision = '0001'
 down_revision = None
@@ -15,7 +16,7 @@ depends_on = None
 def upgrade():
     op.create_table(
         'film',
-        sa.Column('id', sa.String(length=36), primary_key=True),
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
         sa.Column('manufacturer', sa.String(), nullable=False),
         sa.Column('name', sa.String(), nullable=False),
         sa.Column('type', sa.String(), nullable=False),

--- a/api/alembic/versions/0002_create_film_uses_table.py
+++ b/api/alembic/versions/0002_create_film_uses_table.py
@@ -7,6 +7,7 @@ Create Date: 2024-01-02 00:00:00.000000
 
 from alembic import op
 import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
 
 revision = '0002'
 down_revision = '0001'
@@ -17,9 +18,9 @@ depends_on = None
 def upgrade():
     op.create_table(
         'filmuse',
-        sa.Column('id', sa.String(length=36), primary_key=True),
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
         sa.Column('date_used', sa.Date(), nullable=False),
-        sa.Column('film_id', sa.String(length=36), sa.ForeignKey('film.id'), nullable=False),
+        sa.Column('film_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('film.id'), nullable=False),
         sa.Column('camera', sa.String(), nullable=False),
         sa.Column('location', sa.String(), nullable=False),
         sa.Column('developer', sa.String(), nullable=False),


### PR DESCRIPTION
## Summary
- use PostgreSQL UUID columns in migrations so runtime queries match

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f75d7de0c833394abffc7bb93ef9c